### PR TITLE
Change NetworkID for TestNet to 'default'.

### DIFF
--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -11,7 +11,7 @@ export interface NetworkConfig {
 export declare enum NetworkID {
     Local = "local",
     BetaNet = "betanet",
-    TestNet = "testnet",
+    TestNet = "default",
     MainNet = "mainnet"
 }
 export declare const NETWORKS: Map<string, NetworkConfig>;

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,7 @@ export var NetworkID;
 (function (NetworkID) {
     NetworkID["Local"] = "local";
     NetworkID["BetaNet"] = "betanet";
-    NetworkID["TestNet"] = "testnet";
+    NetworkID["TestNet"] = "default";
     NetworkID["MainNet"] = "mainnet";
 })(NetworkID || (NetworkID = {}));
 export const NETWORKS = new Map(Object.entries({

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export interface NetworkConfig {
 export enum NetworkID {
   Local = 'local',
   BetaNet = 'betanet',
-  TestNet = 'testnet',
+  TestNet = 'default',
   MainNet = 'mainnet',
 }
 


### PR DESCRIPTION
To be compatible with `near-cli`, otherwise using signing keys on TestNet will fail.
It's an unfortunate choice over there, but it is what it is...