### PR TITLE
SubmitResult binary format including address in logs

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -38,11 +38,13 @@ declare const _default: {
     OutOfOffset: typeof schema.OutOfOffset;
     CallTooDeep: typeof schema.CallTooDeep;
     TransactionStatus: typeof schema.TransactionStatus;
+    SubmitResultV2: typeof schema.SubmitResultV2;
     SubmitResultV1: typeof schema.SubmitResultV1;
     LegacyExecutionResult: typeof schema.LegacyExecutionResult;
     FunctionCallArgs: typeof schema.FunctionCallArgs;
     GetChainID: typeof schema.GetChainID;
     GetStorageAtArgs: typeof schema.GetStorageAtArgs;
+    LogEventWithAddress: typeof schema.LogEventWithAddress;
     LogEvent: typeof schema.LogEvent;
     MetaCallArgs: typeof schema.MetaCallArgs;
     NewCallArgs: typeof schema.NewCallArgs;

--- a/lib/schema.d.ts
+++ b/lib/schema.d.ts
@@ -19,8 +19,8 @@ export declare class BeginChainArgs extends Assignable {
     constructor(chainID: Uint8Array);
 }
 export declare class SubmitResult {
-    readonly result: SubmitResultV1 | LegacyExecutionResult;
-    constructor(result: SubmitResultV1 | LegacyExecutionResult);
+    readonly result: SubmitResultV2 | SubmitResultV1 | LegacyExecutionResult;
+    constructor(result: SubmitResultV2 | SubmitResultV1 | LegacyExecutionResult);
     output(): Result<Uint8Array, ExecutionError>;
     static decode(input: Buffer): SubmitResult;
 }
@@ -54,6 +54,20 @@ export declare class TransactionStatus extends utils.enums.Enum {
     readonly outOfOffset?: OutOfOffset;
     readonly callTooDeep?: CallTooDeep;
     static decode(input: Buffer): TransactionStatus;
+}
+export declare class SubmitResultV2 extends Assignable {
+    kind: 'SubmitResultV2';
+    static VERSION: 7;
+    readonly version: 7;
+    readonly status: TransactionStatus;
+    readonly gasUsed: number | bigint;
+    readonly logs: LogEventWithAddress[];
+    constructor(args: {
+        status: TransactionStatus;
+        gasUsed: number | bigint | BN;
+        logs: LogEventWithAddress[];
+    });
+    static decode(input: Buffer): SubmitResultV2;
 }
 export declare class SubmitResultV1 extends Assignable {
     kind: 'SubmitResultV1';
@@ -93,6 +107,16 @@ export declare class GetStorageAtArgs extends Assignable {
     address: Uint8Array;
     key: Uint8Array;
     constructor(address: Uint8Array, key: Uint8Array);
+}
+export declare class LogEventWithAddress extends Assignable {
+    readonly address: Uint8Array;
+    readonly topics: RawU256[];
+    readonly data: Uint8Array;
+    constructor(args: {
+        address: Uint8Array | number[];
+        topics: RawU256[];
+        data: Uint8Array | number[];
+    });
 }
 export declare class LogEvent extends Assignable {
     readonly topics: RawU256[];

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -32,6 +32,29 @@ export class SubmitResult {
     }
     output() {
         switch (this.result.kind) {
+            case 'SubmitResultV2':
+                if (this.result.status.success) {
+                    return Ok(Buffer.from(this.result.status.success.output));
+                }
+                else if (this.result.status.revert) {
+                    return Err(this.result.status.revert);
+                }
+                else if (this.result.status.outOfFund) {
+                    return Err(this.result.status.outOfFund);
+                }
+                else if (this.result.status.outOfGas) {
+                    return Err(this.result.status.outOfGas);
+                }
+                else if (this.result.status.outOfOffset) {
+                    return Err(this.result.status.outOfOffset);
+                }
+                else if (this.result.status.callTooDeep) {
+                    return Err(this.result.status.callTooDeep);
+                }
+                else {
+                    // Should be unreachable since one enum variant should be assigned
+                    return Err('LegacyStatusFalse');
+                }
             case 'SubmitResultV1':
                 if (this.result.status.success) {
                     return Ok(Buffer.from(this.result.status.success.output));
@@ -65,6 +88,14 @@ export class SubmitResult {
         }
     }
     static decode(input) {
+        // Note: SubmitResultV1 and LegacyExecutionResult binary formats
+        // will never start with the version byte of SubmitResultV2
+        // because SubmitResultV1 starts with an enum with fewer than 7
+        // variants and LegacyExecutionResult starts with a boolean.
+        if (input[0] == SubmitResultV2.VERSION) {
+            const v2 = SubmitResultV2.decode(input);
+            return new SubmitResult(v2);
+        }
         try {
             const v1 = SubmitResultV1.decode(input);
             return new SubmitResult(v1);
@@ -100,7 +131,23 @@ export class TransactionStatus extends utils.enums.Enum {
         return utils.serialize.deserialize(SCHEMA, TransactionStatus, input);
     }
 }
-// New Borsh-encoded result from the `submit` method.
+// Latest Borsh-encoded result from the `submit` method.
+export class SubmitResultV2 extends Assignable {
+    constructor(args) {
+        super();
+        // discriminator to match on type in `SubmitResult`
+        this.kind = 'SubmitResultV2';
+        this.version = 7;
+        this.status = args.status;
+        this.gasUsed = BigInt(args.gasUsed.toString());
+        this.logs = args.logs;
+    }
+    static decode(input) {
+        return utils.serialize.deserialize(SCHEMA, SubmitResultV2, input);
+    }
+}
+SubmitResultV2.VERSION = 7;
+// Previous Borsh-encoded result from the `submit` method.
 export class SubmitResultV1 extends Assignable {
     constructor(args) {
         super();
@@ -149,6 +196,15 @@ export class GetStorageAtArgs extends Assignable {
         super();
         this.address = address;
         this.key = key;
+    }
+}
+// Borsh-encoded log for use in a latest `SubmitResult`.
+export class LogEventWithAddress extends Assignable {
+    constructor(args) {
+        super();
+        this.address = Buffer.from(args.address);
+        this.topics = args.topics;
+        this.data = Buffer.from(args.data);
     }
 }
 // Borsh-encoded log for use in a `ExecutionResult`.
@@ -314,6 +370,18 @@ const SCHEMA = new Map([
         },
     ],
     [
+        SubmitResultV2,
+        {
+            kind: 'struct',
+            fields: [
+                ['version', 'u8'],
+                ['status', TransactionStatus],
+                ['gasUsed', 'u64'],
+                ['logs', [LogEventWithAddress]],
+            ],
+        },
+    ],
+    [
         SubmitResultV1,
         {
             kind: 'struct',
@@ -354,6 +422,17 @@ const SCHEMA = new Map([
             fields: [
                 ['address', [20]],
                 ['key', [32]],
+            ],
+        },
+    ],
+    [
+        LogEventWithAddress,
+        {
+            kind: 'struct',
+            fields: [
+                ['address', [20]],
+                ['topics', [RawU256]],
+                ['data', ['u8']],
             ],
         },
     ],

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -14,7 +14,55 @@ import {
   OutOfOffset,
   FungibleTokenMetadata,
   InitCallArgs,
+  SubmitResultV2,
+  LogEventWithAddress,
 } from '../lib/schema.js';
+
+test('SubmitResult.decode binary format include address in logs', () => {
+  const expected = new SubmitResult(
+    new SubmitResultV2({
+      status: new TransactionStatus({
+        success: new SuccessStatus({
+          output: new Uint8Array([]),
+        }),
+      }),
+      gasUsed: 68586,
+      logs: [
+        new LogEventWithAddress({
+          address: hexToBytes('0x085a144bc0c2bd3b57c55fa1a5742620218832bc'),
+          topics: [
+            new RawU256(
+              hexToBytes(
+                '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+              )
+            ),
+            new RawU256(
+              hexToBytes(
+                '0x0000000000000000000000000000000000000000000000000000000000000000'
+              )
+            ),
+            new RawU256(
+              hexToBytes(
+                '0x00000000000000000000000011e84de622b5728cea4f465a25cbebfea22957db'
+              )
+            ),
+          ],
+          data: hexToBytes(
+            '0x000000000000000000000000000000000000000000000000000000000000000a'
+          ),
+        }),
+      ],
+    })
+  );
+
+  const bytes = expected.result.encode();
+  const bytes_hex = bytesToHex(bytes);
+  const expected_hex =
+    '0x070000000000ea0b01000000000001000000085a144bc0c2bd3b57c55fa1a5742620218832bc03000000ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011e84de622b5728cea4f465a25cbebfea22957db20000000000000000000000000000000000000000000000000000000000000000000000a';
+  expect(bytes_hex).toBe(expected_hex);
+  const decoded = SubmitResult.decode(Buffer.from(bytes));
+  expect(decoded).toEqual(expected);
+});
 
 test('SubmitResult.decode new binary format -- Success', () => {
   const expected = new SubmitResult(


### PR DESCRIPTION
This is the companion PR for https://github.com/aurora-is-near/aurora-engine/pull/299. It ensures the new `SubmitResult` binary format can be parsed by the JS library.