### PR TITLE
Add +1 offset for `eth_getCode`.

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -223,6 +223,9 @@ export class Engine {
     }
     async getCode(address, options) {
         const args = address.toBytes();
+        if (typeof options === 'object' && options.block) {
+            options.block = (options.block + 1);
+        }
         return await this.callFunction('get_code', args, options);
     }
     async getBalance(address, options) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -382,6 +382,9 @@ export class Engine {
     options?: ViewOptions
   ): Promise<Result<Bytecode, Error>> {
     const args = address.toBytes();
+    if (typeof options === 'object' && options.block) {
+      options.block = ((options.block as number) + 1) as BlockID;
+    }
     return await this.callFunction('get_code', args, options);
   }
 


### PR DESCRIPTION
https://explorer.testnet.aurora.dev/address/0x6D7A65D4e761Ae5f6832735DB18E2c32132d7ff9/transactions

This specific address has a contract deployed. Block `74148937`

When doing RPC call `http post https://testnet.aurora.dev jsonrpc=2.0 id=1 method=eth_getCode params:='["0x6d7a65d4e761ae5f6832735db18e2c32132d7ff9", "74148937"]'`, response is:

```
{
    "id": "1",
    "jsonrpc": "2.0",
    "result": "0x"
}
```

But when using `latest` instead of block. Or any next block after `74148937`, eth_getCode gives a proper response.

Ex.: `http post https://testnet.aurora.dev jsonrpc=2.0 id=1 method=eth_getCode params:='["0x6d7a65d4e761ae5f6832735db18e2c32132d7ff9", "latest"]'` or 
`http post https://testnet.aurora.dev jsonrpc=2.0 id=1 method=eth_getCode params:='["0x6d7a65d4e761ae5f6832735db18e2c32132d7ff9", "74148938"]'` 

This issue is not specifically relates to this block and contract. This is system wide, which causes issues to some clients. In my case blockscout.

When calling near core RPC directly - behaviour is similar.

`http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare method=query params:='{ "request_type": "call_function", "account_id": "aurora", "method_name": "get_code", "args_base64": "bXpl1Odhrl9oMnNdsY4sMhMtf/k=", "block_id": 74148937}'` - will not return bytecode, while

`http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare method=query params:='{ "request_type": "call_function", "account_id": "aurora", "method_name": "get_code", "args_base64": "bXpl1Odhrl9oMnNdsY4sMhMtf/k=", "block_id": 74148938}'` 
or 
`http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare method=query params:='{ "request_type": "call_function", "account_id": "aurora", "method_name": "get_code", "args_base64": "bXpl1Odhrl9oMnNdsY4sMhMtf/k=", "finality": "final"}'` does.

Cause:

There is a sort of "off by 1" problem here it's because of the details of how Near processes transactions. If a transaction is included in block X then no state changes actually occur, the transaction is only converted into a receipt. In block X + 1 that receipt will be processed, causing the state change.  The reason for this transaction into receipt complexity is because of sharding on Near.

Fix:

Querying Near at a height 1 greater than the query it received.

