### PR TITLE
Add Gas Burned to Error message in callMutativeFunction

### DIFF
--- a/lib/engine.d.ts
+++ b/lib/engine.d.ts
@@ -100,4 +100,5 @@ export declare class Engine {
     protected callFunction(methodName: string, args?: Uint8Array, options?: ViewOptions): Promise<Result<Buffer, Error>>;
     protected callMutativeFunction(methodName: string, args?: Uint8Array): Promise<Result<TransactionOutcome, Error>>;
     private prepareInput;
+    private errorWithBurnedGas;
 }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -327,12 +327,13 @@ export class Engine {
             //assert(error instanceof ServerTransactionError);
             switch (error?.type) {
                 case 'FunctionCallError': {
+                    const gasBurned = error?.transaction_outcome?.outcome?.gas_burnt || 0;
                     const errorKind = error?.kind?.ExecutionError;
                     if (errorKind) {
                         const errorCode = errorKind.replace('Smart contract panicked: ', '');
-                        return Err(errorCode);
+                        return Err(this.errorWithBurnedGas(errorCode, gasBurned));
                     }
-                    return Err(error.message);
+                    return Err(this.errorWithBurnedGas(error.message, gasBurned));
                 }
                 case 'MethodNotFound':
                     return Err(error.message);
@@ -348,5 +349,8 @@ export class Engine {
         if (typeof args === 'string')
             return Buffer.from(parseHexString(args));
         return Buffer.from(args);
+    }
+    errorWithBurnedGas(message, gasBurned) {
+        return `${message}|${gasBurned.toString()}`;
     }
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -550,15 +550,16 @@ export class Engine {
       //assert(error instanceof ServerTransactionError);
       switch (error?.type) {
         case 'FunctionCallError': {
+          const gasBurned = error?.transaction_outcome?.outcome?.gas_burnt || 0
           const errorKind = error?.kind?.ExecutionError;
           if (errorKind) {
             const errorCode = errorKind.replace(
               'Smart contract panicked: ',
               ''
             );
-            return Err(errorCode);
+            return Err(this.errorWithBurnedGas(errorCode, gasBurned));
           }
-          return Err(error.message);
+          return Err(this.errorWithBurnedGas(error.message, gasBurned));
         }
         case 'MethodNotFound':
           return Err(error.message);
@@ -575,4 +576,9 @@ export class Engine {
       return Buffer.from(parseHexString(args as string));
     return Buffer.from(args);
   }
+
+  private errorWithBurnedGas(message: string, gasBurned: number): string {
+    return `${message}|${gasBurned.toString()}`
+  }
+
 }


### PR DESCRIPTION
Propagate gas burned during callMutativeFunction call error, so it can be grabbed in `aurora-relayer`. 