### PR TITLE
Return transaction id for errors from Engine#callMutativeFunction()

### DIFF
--- a/lib/engine.d.ts
+++ b/lib/engine.d.ts
@@ -62,6 +62,10 @@ export declare class EngineState {
     storage: EngineStorage;
     constructor(storage?: EngineStorage);
 }
+export interface TransactionErrorDetails {
+    tx?: string;
+    gasBurned?: string;
+}
 export declare class Engine {
     readonly near: NEAR.Near;
     readonly keyStore: KeyStore;
@@ -100,5 +104,5 @@ export declare class Engine {
     protected callFunction(methodName: string, args?: Uint8Array, options?: ViewOptions): Promise<Result<Buffer, Error>>;
     protected callMutativeFunction(methodName: string, args?: Uint8Array): Promise<Result<TransactionOutcome, Error>>;
     private prepareInput;
-    private errorWithBurnedGas;
+    private errorWithDetails;
 }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -327,13 +327,16 @@ export class Engine {
             //assert(error instanceof ServerTransactionError);
             switch (error?.type) {
                 case 'FunctionCallError': {
-                    const gasBurned = error?.transaction_outcome?.outcome?.gas_burnt || 0;
+                    const details = {
+                        tx: error?.transaction_outcome?.id,
+                        gasBurned: error?.transaction_outcome?.outcome?.gas_burnt || 0,
+                    };
                     const errorKind = error?.kind?.ExecutionError;
                     if (errorKind) {
                         const errorCode = errorKind.replace('Smart contract panicked: ', '');
-                        return Err(this.errorWithBurnedGas(errorCode, gasBurned));
+                        return Err(this.errorWithDetails(errorCode, details));
                     }
-                    return Err(this.errorWithBurnedGas(error.message, gasBurned));
+                    return Err(this.errorWithDetails(error.message, details));
                 }
                 case 'MethodNotFound':
                     return Err(error.message);
@@ -350,7 +353,7 @@ export class Engine {
             return Buffer.from(parseHexString(args));
         return Buffer.from(args);
     }
-    errorWithBurnedGas(message, gasBurned) {
-        return `${message}|${gasBurned.toString()}`;
+    errorWithDetails(message, details) {
+        return `${message}|${JSON.stringify(details)}`;
     }
 }


### PR DESCRIPTION
Propagate transaction id during `callMutativeFunction` call error, so it can be grabbed in aurora-relayer.