### PR TITLE
Add Gas Burned to `SubmitResult` on `engine.submit`

### DIFF
--- a/lib/engine.d.ts
+++ b/lib/engine.d.ts
@@ -3,7 +3,7 @@ import { AccountID, Address } from './account.js';
 import { BlockHash, BlockHeight, BlockID, BlockOptions, BlockProxy } from './block.js';
 import { KeyStore } from './key_store.js';
 import { Quantity, Result, U256 } from './prelude.js';
-import { SubmitResult, OutOfGas } from './schema.js';
+import { OutOfGas, GasBurned, WrappedSubmitResult } from './schema.js';
 import { TransactionID } from './transaction.js';
 import * as NEAR from 'near-api-js';
 import { ResErr } from '@hqoss/monads/dist/lib/result/result';
@@ -16,6 +16,8 @@ export declare type Error = string;
 export interface TransactionOutcome {
     id: TransactionID;
     output: Uint8Array;
+    gasBurned?: GasBurned;
+    tx?: string;
 }
 export interface BlockInfo {
     hash: BlockHash;
@@ -92,7 +94,7 @@ export declare class Engine {
     getChainID(options?: ViewOptions): Promise<Result<ChainID, Error>>;
     deployCode(bytecode: Bytecodeish): Promise<Result<Address, Error>>;
     call(contract: Address, input: Uint8Array | string): Promise<Result<Uint8Array, Error>>;
-    submit(input: Uint8Array | string): Promise<Result<SubmitResult, Error>>;
+    submit(input: Uint8Array | string): Promise<Result<WrappedSubmitResult, Error>>;
     view(sender: Address, address: Address, amount: Quantity, input: Uint8Array | string, options?: ViewOptions): Promise<Result<Uint8Array | ResErr<unknown, OutOfGas>, Error>>;
     getCode(address: Address, options?: ViewOptions): Promise<Result<Bytecode, Error>>;
     getBalance(address: Address, options?: ViewOptions): Promise<Result<U256, Error>>;

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -4,7 +4,7 @@ import { BlockProxy, parseBlockID, } from './block.js';
 import { NETWORKS } from './config.js';
 import { KeyStore } from './key_store.js';
 import { Err, Ok } from './prelude.js';
-import { SubmitResult, FunctionCallArgs, GetStorageAtArgs, InitCallArgs, NewCallArgs, ViewCallArgs, FungibleTokenMetadata, TransactionStatus, } from './schema.js';
+import { SubmitResult, FunctionCallArgs, GetStorageAtArgs, InitCallArgs, NewCallArgs, ViewCallArgs, FungibleTokenMetadata, TransactionStatus, WrappedSubmitResult, } from './schema.js';
 import { TransactionID } from './transaction.js';
 import { defaultAbiCoder } from '@ethersproject/abi';
 import { arrayify as parseHexString } from '@ethersproject/bytes';
@@ -192,7 +192,9 @@ export class Engine {
                 //console.error(error); // DEBUG
                 return Err('ERR_INVALID_TX');
             }
-            return (await this.callMutativeFunction('submit', inputBytes)).map(({ output }) => SubmitResult.decode(Buffer.from(output)));
+            return (await this.callMutativeFunction('submit', inputBytes)).map(({ output, gasBurned, tx }) => {
+                return new WrappedSubmitResult(SubmitResult.decode(Buffer.from(output)), gasBurned, tx);
+            });
         }
         catch (error) {
             //console.error(error); // DEBUG
@@ -322,6 +324,8 @@ export class Engine {
                 return Ok({
                     id: TransactionID.fromHex(result.transaction.hash),
                     output: Buffer.from(result.status.SuccessValue, 'base64'),
+                    tx: result?.transaction_outcome?.id,
+                    gasBurned: result?.transaction_outcome?.outcome?.gas_burnt || 0,
                 });
             }
             return Err(result.toString()); // FIXME: unreachable?

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -30,6 +30,7 @@ declare const _default: {
     Transaction: typeof transaction.Transaction;
     BeginBlockArgs: typeof schema.BeginBlockArgs;
     BeginChainArgs: typeof schema.BeginChainArgs;
+    WrappedSubmitResult: typeof schema.WrappedSubmitResult;
     SubmitResult: typeof schema.SubmitResult;
     SuccessStatus: typeof schema.SuccessStatus;
     RevertStatus: typeof schema.RevertStatus;

--- a/lib/schema.d.ts
+++ b/lib/schema.d.ts
@@ -2,6 +2,7 @@
 import { Result } from '@hqoss/monads';
 import BN from 'bn.js';
 import { utils } from 'near-api-js';
+export declare type GasBurned = number | bigint | undefined;
 declare abstract class Assignable {
     encode(): Uint8Array;
 }
@@ -17,6 +18,12 @@ export declare class BeginBlockArgs extends Assignable {
 export declare class BeginChainArgs extends Assignable {
     chainID: Uint8Array;
     constructor(chainID: Uint8Array);
+}
+export declare class WrappedSubmitResult extends Assignable {
+    submitResult: SubmitResult;
+    gasBurned: GasBurned;
+    tx: string | undefined;
+    constructor(submitResult: SubmitResult, gasBurned: GasBurned, tx: string | undefined);
 }
 export declare class SubmitResult {
     readonly result: SubmitResultV2 | SubmitResultV1 | LegacyExecutionResult;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -26,6 +26,14 @@ export class BeginChainArgs extends Assignable {
         this.chainID = chainID;
     }
 }
+export class WrappedSubmitResult extends Assignable {
+    constructor(submitResult, gasBurned, tx) {
+        super();
+        this.submitResult = submitResult;
+        this.gasBurned = gasBurned;
+        this.tx = tx;
+    }
+}
 export class SubmitResult {
     constructor(result) {
         this.result = result;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,6 +5,8 @@ import BN from 'bn.js';
 import { utils } from 'near-api-js';
 import { bytesToHex } from './utils.js';
 
+export type GasBurned = number | bigint | undefined;
+
 abstract class Assignable {
   encode(): Uint8Array {
     return utils.serialize.serialize(SCHEMA, this);
@@ -103,6 +105,16 @@ export class SubmitResult {
       const legacy = LegacyExecutionResult.decode(input);
       return new SubmitResult(legacy);
     }
+  }
+}
+
+export class WrappedSubmitResult extends Assignable {
+  constructor(
+    public submitResult: SubmitResult,
+    public gasBurned: GasBurned,
+    public tx: string | undefined
+  ) {
+    super();
   }
 }
 


### PR DESCRIPTION
We need additional GasBurned Header and Transaction for `eth_sendRawTransaction` on `aurora-relayer`. This requires passing through these data from `aurora.js`. Extending SubmitResult with `GasBurned `and `tx` so it can be later extracted in `aurora-relayer`