### PR TITLE
Extract complete transaction gas burned

### DIFF
--- a/lib/engine.d.ts
+++ b/lib/engine.d.ts
@@ -66,7 +66,7 @@ export declare class EngineState {
 }
 export interface TransactionErrorDetails {
     tx?: string;
-    gasBurned?: string;
+    gasBurned?: GasBurned;
 }
 export declare class Engine {
     readonly near: NEAR.Near;
@@ -107,4 +107,5 @@ export declare class Engine {
     protected callMutativeFunction(methodName: string, args?: Uint8Array): Promise<Result<TransactionOutcome, Error>>;
     private prepareInput;
     private errorWithDetails;
+    private transactionGasBurned;
 }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -6,6 +6,7 @@ import { KeyStore } from './key_store.js';
 import { Err, Ok } from './prelude.js';
 import { SubmitResult, FunctionCallArgs, GetStorageAtArgs, InitCallArgs, NewCallArgs, ViewCallArgs, FungibleTokenMetadata, TransactionStatus, WrappedSubmitResult, } from './schema.js';
 import { TransactionID } from './transaction.js';
+import { base58ToBytes } from './utils.js';
 import { defaultAbiCoder } from '@ethersproject/abi';
 import { arrayify as parseHexString } from '@ethersproject/bytes';
 import { parse as parseRawTransaction } from '@ethersproject/transactions';
@@ -321,11 +322,12 @@ export class Engine {
             const result = await this.signer.functionCall(this.contractID.toString(), methodName, this.prepareInput(args), gas);
             if (typeof result.status === 'object' &&
                 typeof result.status.SuccessValue === 'string') {
+                const transactionId = result?.transaction_outcome?.id;
                 return Ok({
                     id: TransactionID.fromHex(result.transaction.hash),
                     output: Buffer.from(result.status.SuccessValue, 'base64'),
-                    tx: result?.transaction_outcome?.id,
-                    gasBurned: result?.transaction_outcome?.outcome?.gas_burnt || 0,
+                    tx: transactionId,
+                    gasBurned: await this.transactionGasBurned(transactionId),
                 });
             }
             return Err(result.toString()); // FIXME: unreachable?
@@ -334,9 +336,10 @@ export class Engine {
             //assert(error instanceof ServerTransactionError);
             switch (error?.type) {
                 case 'FunctionCallError': {
+                    const transactionId = error?.transaction_outcome?.id;
                     const details = {
-                        tx: error?.transaction_outcome?.id,
-                        gasBurned: error?.transaction_outcome?.outcome?.gas_burnt || 0,
+                        tx: transactionId,
+                        gasBurned: await this.transactionGasBurned(transactionId),
                     };
                     const errorKind = error?.kind?.ExecutionError;
                     if (errorKind) {
@@ -362,5 +365,16 @@ export class Engine {
     }
     errorWithDetails(message, details) {
         return `${message}|${JSON.stringify(details)}`;
+    }
+    async transactionGasBurned(id) {
+        try {
+            const transactionStatus = await this.near.connection.provider.txStatus(base58ToBytes(id), this.contractID.toString());
+            const receiptsGasBurned = transactionStatus.receipts_outcome.reduce((sum, value) => sum + value.outcome.gas_burnt, 0);
+            const transactionGasBurned = transactionStatus.transaction_outcome.outcome.gas_burnt || 0;
+            return receiptsGasBurned + transactionGasBurned;
+        }
+        catch (error) {
+            return 0;
+        }
     }
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -30,8 +30,8 @@ declare const _default: {
     Transaction: typeof transaction.Transaction;
     BeginBlockArgs: typeof schema.BeginBlockArgs;
     BeginChainArgs: typeof schema.BeginChainArgs;
-    WrappedSubmitResult: typeof schema.WrappedSubmitResult;
     SubmitResult: typeof schema.SubmitResult;
+    WrappedSubmitResult: typeof schema.WrappedSubmitResult;
     SuccessStatus: typeof schema.SuccessStatus;
     RevertStatus: typeof schema.RevertStatus;
     OutOfGas: typeof schema.OutOfGas;

--- a/lib/schema.d.ts
+++ b/lib/schema.d.ts
@@ -19,17 +19,17 @@ export declare class BeginChainArgs extends Assignable {
     chainID: Uint8Array;
     constructor(chainID: Uint8Array);
 }
-export declare class WrappedSubmitResult extends Assignable {
-    submitResult: SubmitResult;
-    gasBurned: GasBurned;
-    tx: string | undefined;
-    constructor(submitResult: SubmitResult, gasBurned: GasBurned, tx: string | undefined);
-}
 export declare class SubmitResult {
     readonly result: SubmitResultV2 | SubmitResultV1 | LegacyExecutionResult;
     constructor(result: SubmitResultV2 | SubmitResultV1 | LegacyExecutionResult);
     output(): Result<Uint8Array, ExecutionError>;
     static decode(input: Buffer): SubmitResult;
+}
+export declare class WrappedSubmitResult extends Assignable {
+    submitResult: SubmitResult;
+    gasBurned: GasBurned;
+    tx: string | undefined;
+    constructor(submitResult: SubmitResult, gasBurned: GasBurned, tx: string | undefined);
 }
 export declare type LegacyStatusFalse = 'LegacyStatusFalse';
 export declare type ExecutionError = RevertStatus | OutOfGas | OutOfFund | OutOfOffset | CallTooDeep | LegacyStatusFalse;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -26,14 +26,6 @@ export class BeginChainArgs extends Assignable {
         this.chainID = chainID;
     }
 }
-export class WrappedSubmitResult extends Assignable {
-    constructor(submitResult, gasBurned, tx) {
-        super();
-        this.submitResult = submitResult;
-        this.gasBurned = gasBurned;
-        this.tx = tx;
-    }
-}
 export class SubmitResult {
     constructor(result) {
         this.result = result;
@@ -112,6 +104,14 @@ export class SubmitResult {
             const legacy = LegacyExecutionResult.decode(input);
             return new SubmitResult(legacy);
         }
+    }
+}
+export class WrappedSubmitResult extends Assignable {
+    constructor(submitResult, gasBurned, tx) {
+        super();
+        this.submitResult = submitResult;
+        this.gasBurned = gasBurned;
+        this.tx = tx;
     }
 }
 export class SuccessStatus extends utils.enums.Assignable {


### PR DESCRIPTION
We need `gas_burned` that is used by `aurora-relayer`.
Turns out that `gas_burned`, that is returned by `functionCall`, includes gas_burned only for receipt creation. To get full transaction `gas_burned` we need to grab txStatus. 