### PR TITLE
Support for new CallArgs enum

### DIFF
--- a/lib/engine.d.ts
+++ b/lib/engine.d.ts
@@ -93,7 +93,7 @@ export declare class Engine {
     getBridgeProvider(options?: ViewOptions): Promise<Result<AccountID, Error>>;
     getChainID(options?: ViewOptions): Promise<Result<ChainID, Error>>;
     deployCode(bytecode: Bytecodeish): Promise<Result<Address, Error>>;
-    call(contract: Address, input: Uint8Array | string): Promise<Result<Uint8Array, Error>>;
+    call(contract: Address, input: Uint8Array | string, value?: number | bigint | string): Promise<Result<Uint8Array, Error>>;
     submit(input: Uint8Array | string): Promise<Result<WrappedSubmitResult, Error>>;
     view(sender: Address, address: Address, amount: Quantity, input: Uint8Array | string, options?: ViewOptions): Promise<Result<Uint8Array | ResErr<unknown, OutOfGas>, Error>>;
     getCode(address: Address, options?: ViewOptions): Promise<Result<Bytecode, Error>>;
@@ -105,6 +105,7 @@ export declare class Engine {
     getStorage(): Promise<Result<EngineStorage, Error>>;
     protected callFunction(methodName: string, args?: Uint8Array, options?: ViewOptions): Promise<Result<Buffer, Error>>;
     protected callMutativeFunction(methodName: string, args?: Uint8Array): Promise<Result<TransactionOutcome, Error>>;
+    private prepareAmount;
     private prepareInput;
     private errorWithDetails;
     private transactionGasBurned;

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -4,7 +4,7 @@ import { BlockProxy, parseBlockID, } from './block.js';
 import { NETWORKS } from './config.js';
 import { KeyStore } from './key_store.js';
 import { Err, Ok } from './prelude.js';
-import { SubmitResult, FunctionCallArgs, GetStorageAtArgs, InitCallArgs, NewCallArgs, ViewCallArgs, FungibleTokenMetadata, TransactionStatus, WrappedSubmitResult, } from './schema.js';
+import { SubmitResult, FunctionCallArgsV2, GetStorageAtArgs, InitCallArgs, NewCallArgs, ViewCallArgs, FungibleTokenMetadata, TransactionStatus, WrappedSubmitResult, CallArgs, } from './schema.js';
 import { TransactionID } from './transaction.js';
 import { base58ToBytes } from './utils.js';
 import { defaultAbiCoder } from '@ethersproject/abi';
@@ -175,8 +175,13 @@ export class Engine {
             return Address.parse(Buffer.from(result.output().unwrap()).toString('hex')).unwrap();
         });
     }
-    async call(contract, input) {
-        const args = new FunctionCallArgs(contract.toBytes(), this.prepareInput(input));
+    async call(contract, input, value) {
+        const inner_args = new FunctionCallArgsV2({
+            contract: contract.toBytes(),
+            value: this.prepareAmount(value),
+            input: this.prepareInput(input),
+        });
+        const args = new CallArgs({ functionCallArgsV2: inner_args });
         return (await this.callMutativeFunction('call', args.encode())).map(({ output }) => output);
     }
     async submit(input) {
@@ -355,6 +360,12 @@ export class Engine {
                     return Err(error.toString());
             }
         }
+    }
+    prepareAmount(value) {
+        if (typeof value === 'undefined')
+            return toBufferBE(BigInt(0), 32);
+        const number = BigInt(value);
+        return toBufferBE(number, 32);
     }
     prepareInput(args) {
         if (typeof args === 'undefined')

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -42,7 +42,9 @@ declare const _default: {
     SubmitResultV2: typeof schema.SubmitResultV2;
     SubmitResultV1: typeof schema.SubmitResultV1;
     LegacyExecutionResult: typeof schema.LegacyExecutionResult;
-    FunctionCallArgs: typeof schema.FunctionCallArgs;
+    CallArgs: typeof schema.CallArgs;
+    FunctionCallArgsV2: typeof schema.FunctionCallArgsV2;
+    FunctionCallArgsV1: typeof schema.FunctionCallArgsV1;
     GetChainID: typeof schema.GetChainID;
     GetStorageAtArgs: typeof schema.GetStorageAtArgs;
     LogEventWithAddress: typeof schema.LogEventWithAddress;

--- a/lib/schema.d.ts
+++ b/lib/schema.d.ts
@@ -102,10 +102,29 @@ export declare class LegacyExecutionResult extends Assignable {
     });
     static decode(input: Buffer): LegacyExecutionResult;
 }
-export declare class FunctionCallArgs extends Assignable {
-    contract: Uint8Array;
-    input: Uint8Array;
-    constructor(contract: Uint8Array, input: Uint8Array);
+export declare class CallArgs extends utils.enums.Enum {
+    readonly functionCallArgsV2?: FunctionCallArgsV2;
+    readonly functionCallArgsV1?: FunctionCallArgsV1;
+    static decode(input: Buffer): CallArgs;
+    encode(): Uint8Array;
+}
+export declare class FunctionCallArgsV2 extends Assignable {
+    readonly contract: Uint8Array;
+    readonly value: Uint8Array;
+    readonly input: Uint8Array;
+    constructor(args: {
+        contract: Uint8Array;
+        value: Uint8Array;
+        input: Uint8Array;
+    });
+}
+export declare class FunctionCallArgsV1 extends Assignable {
+    readonly contract: Uint8Array;
+    readonly input: Uint8Array;
+    constructor(args: {
+        contract: Uint8Array;
+        input: Uint8Array;
+    });
 }
 export declare class GetChainID extends Assignable {
     constructor();

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -184,12 +184,29 @@ export class LegacyExecutionResult extends Assignable {
         return utils.serialize.deserialize(SCHEMA, LegacyExecutionResult, input);
     }
 }
-// Borsh-encoded parameters for the `call` method.
-export class FunctionCallArgs extends Assignable {
-    constructor(contract, input) {
+export class CallArgs extends utils.enums.Enum {
+    static decode(input) {
+        return utils.serialize.deserialize(SCHEMA, CallArgs, input);
+    }
+    encode() {
+        return utils.serialize.serialize(SCHEMA, this);
+    }
+}
+// New variant Borsh-encoded parameters for the `call` method.
+export class FunctionCallArgsV2 extends Assignable {
+    constructor(args) {
         super();
-        this.contract = contract;
-        this.input = input;
+        this.contract = Buffer.from(args.contract);
+        this.value = Buffer.from(args.value);
+        this.input = Buffer.from(args.input);
+    }
+}
+// Legacy Borsh-encoded parameters for the `call` method.
+export class FunctionCallArgsV1 extends Assignable {
+    constructor(args) {
+        super();
+        this.contract = Buffer.from(args.contract);
+        this.input = Buffer.from(args.input);
     }
 }
 // Borsh-encoded parameters for the `get_chain_id` method.
@@ -413,7 +430,29 @@ const SCHEMA = new Map([
         },
     ],
     [
-        FunctionCallArgs,
+        CallArgs,
+        {
+            kind: 'enum',
+            field: 'enum',
+            values: [
+                ['functionCallArgsV2', FunctionCallArgsV2],
+                ['functionCallArgsV1', FunctionCallArgsV1],
+            ],
+        },
+    ],
+    [
+        FunctionCallArgsV2,
+        {
+            kind: 'struct',
+            fields: [
+                ['contract', [20]],
+                ['value', [32]],
+                ['input', ['u8']],
+            ],
+        },
+    ],
+    [
+        FunctionCallArgsV1,
         {
             kind: 'struct',
             fields: [

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -14,7 +14,7 @@ import { KeyStore } from './key_store.js';
 import { Err, Ok, Quantity, Result, U256 } from './prelude.js';
 import {
   SubmitResult,
-  FunctionCallArgs,
+  FunctionCallArgsV2,
   GetStorageAtArgs,
   InitCallArgs,
   NewCallArgs,
@@ -24,6 +24,7 @@ import {
   OutOfGas,
   GasBurned,
   WrappedSubmitResult,
+  CallArgs,
 } from './schema.js';
 import { TransactionID } from './transaction.js';
 
@@ -322,12 +323,15 @@ export class Engine {
 
   async call(
     contract: Address,
-    input: Uint8Array | string
+    input: Uint8Array | string,
+    value?: number | bigint | string
   ): Promise<Result<Uint8Array, Error>> {
-    const args = new FunctionCallArgs(
-      contract.toBytes(),
-      this.prepareInput(input)
-    );
+    const inner_args = new FunctionCallArgsV2({
+      contract: contract.toBytes(),
+      value: this.prepareAmount(value),
+      input: this.prepareInput(input),
+    });
+    const args = new CallArgs({ functionCallArgsV2: inner_args });
     return (await this.callMutativeFunction('call', args.encode())).map(
       ({ output }) => output
     );
@@ -594,6 +598,13 @@ export class Engine {
           return Err(error.toString());
       }
     }
+  }
+
+  private prepareAmount(value?: number | bigint | string): Buffer {
+    if (typeof value === 'undefined') return toBufferBE(BigInt(0), 32);
+
+    const number = BigInt(value);
+    return toBufferBE(number, 32);
   }
 
   private prepareInput(args?: Uint8Array | string): Buffer {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -241,10 +241,46 @@ export class LegacyExecutionResult extends Assignable {
   }
 }
 
-// Borsh-encoded parameters for the `call` method.
-export class FunctionCallArgs extends Assignable {
-  constructor(public contract: Uint8Array, public input: Uint8Array) {
+export class CallArgs extends utils.enums.Enum {
+  public readonly functionCallArgsV2?: FunctionCallArgsV2;
+  public readonly functionCallArgsV1?: FunctionCallArgsV1;
+
+  static decode(input: Buffer): CallArgs {
+    return utils.serialize.deserialize(SCHEMA, CallArgs, input);
+  }
+
+  encode(): Uint8Array {
+    return utils.serialize.serialize(SCHEMA, this);
+  }
+}
+
+// New variant Borsh-encoded parameters for the `call` method.
+export class FunctionCallArgsV2 extends Assignable {
+  public readonly contract: Uint8Array;
+  public readonly value: Uint8Array;
+  public readonly input: Uint8Array;
+
+  constructor(args: {
+    contract: Uint8Array;
+    value: Uint8Array;
+    input: Uint8Array;
+  }) {
     super();
+    this.contract = Buffer.from(args.contract);
+    this.value = Buffer.from(args.value);
+    this.input = Buffer.from(args.input);
+  }
+}
+
+// Legacy Borsh-encoded parameters for the `call` method.
+export class FunctionCallArgsV1 extends Assignable {
+  public readonly contract: Uint8Array;
+  public readonly input: Uint8Array;
+
+  constructor(args: { contract: Uint8Array; input: Uint8Array }) {
+    super();
+    this.contract = Buffer.from(args.contract);
+    this.input = Buffer.from(args.input);
   }
 }
 
@@ -505,7 +541,29 @@ const SCHEMA = new Map<Function, any>([
     },
   ],
   [
-    FunctionCallArgs,
+    CallArgs,
+    {
+      kind: 'enum',
+      field: 'enum',
+      values: [
+        ['functionCallArgsV2', FunctionCallArgsV2],
+        ['functionCallArgsV1', FunctionCallArgsV1],
+      ],
+    },
+  ],
+  [
+    FunctionCallArgsV2,
+    {
+      kind: 'struct',
+      fields: [
+        ['contract', [20]],
+        ['value', [32]],
+        ['input', ['u8']],
+      ],
+    },
+  ],
+  [
+    FunctionCallArgsV1,
     {
       kind: 'struct',
       fields: [

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1,3 +1,4 @@
+import { toBufferBE } from 'bigint-buffer';
 import { hexToBytes, bytesToHex } from '../lib/utils.js';
 import {
   SubmitResultV1,
@@ -16,7 +17,45 @@ import {
   InitCallArgs,
   SubmitResultV2,
   LogEventWithAddress,
+  FunctionCallArgsV1,
+  FunctionCallArgsV2,
+  CallArgs,
 } from '../lib/schema.js';
+
+test('CallArgs v1', () => {
+  const inner_args = new FunctionCallArgsV1({
+    contract: hexToBytes('0x24a0ff6eb0a5779b1c7bfbd520ec7b258c4e2fbd'),
+    input: hexToBytes('0xdeadbeef'),
+  });
+  const args = new CallArgs({ functionCallArgsV1: inner_args });
+  const bytes = args.encode();
+  const bytes_hex = bytesToHex(bytes);
+
+  const expected_hex =
+    '0x0124a0ff6eb0a5779b1c7bfbd520ec7b258c4e2fbd04000000deadbeef';
+  expect(expected_hex).toBe(bytes_hex);
+
+  const decoded = CallArgs.decode(Buffer.from(bytes));
+  expect(decoded).toEqual(args);
+});
+
+test('CallArgs v2', () => {
+  const inner_args = new FunctionCallArgsV2({
+    contract: hexToBytes('0xfd70354c0895a34ba001d9db2843fc59c809dbfa'),
+    input: hexToBytes('0xdeadbeef'),
+    value: toBufferBE(BigInt('123456789'), 32),
+  });
+  const args = new CallArgs({ functionCallArgsV2: inner_args });
+  const bytes = args.encode();
+  const bytes_hex = bytesToHex(bytes);
+
+  const expected_hex =
+    '0x00fd70354c0895a34ba001d9db2843fc59c809dbfa00000000000000000000000000000000000000000000000000000000075bcd1504000000deadbeef';
+  expect(expected_hex).toBe(bytes_hex);
+
+  const decoded = CallArgs.decode(Buffer.from(bytes));
+  expect(decoded).toEqual(args);
+});
 
 test('SubmitResult.decode binary format include address in logs', () => {
   const expected = new SubmitResult(


### PR DESCRIPTION
This enables the ability to use the Engine's `call` method to send ETH. This is important because it is the only way to get the gas fees from relayer accounts (ie accounts that call the Engine's `submit` method on behalf of users).

Fixes #33 