### PR TITLE
Handle gasPrice null

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -68,7 +68,7 @@ export class Transaction {
             const transaction = parseRawTransaction(Buffer.from(functionCall.args, 'base64')); // throws Error
             const receiptIDs = outcome.transaction_outcome?.outcome?.receipt_ids;
             const executionResult = SubmitResult.decode(outcomeBuffer); // throws BorshError
-            return Some(new Transaction(transaction.nonce, BigInt(transaction.gasPrice.toString()), BigInt(transaction.gasLimit.toString()), // FIXME: #16, #17
+            return Some(new Transaction(transaction.nonce, BigInt(transaction.gasPrice?.toString() || 0), BigInt(transaction.gasLimit.toString()), // FIXME: #16, #17
             Address.parse(transaction.to).ok(), BigInt(transaction.value.toString()), hexToBytes(transaction.data), BigInt(transaction.v), BigInt(transaction.r), BigInt(transaction.s), transaction.from
                 ? Address.parse(transaction.from).unwrap()
                 : undefined, transaction.hash, executionResult, {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -111,7 +111,7 @@ export class Transaction {
       return Some(
         new Transaction(
           transaction.nonce,
-          BigInt(transaction.gasPrice.toString()),
+          BigInt(transaction.gasPrice?.toString() || 0),
           BigInt(transaction.gasLimit.toString()), // FIXME: #16, #17
           Address.parse(transaction.to).ok(),
           BigInt(transaction.value.toString()),


### PR DESCRIPTION
Fix for this issue:
https://github.com/aurora-is-near/aurora-relayer/issues/233

In that transaction we have `gasPrice: null` and because of this `aurora.js` can't handle such transaction
https://gist.github.com/zakerikk/719704113ad5fda2f884fb62a102569d#file-1-log-L10

```
AURORA_TX 0x579c1fea414d46b188e322c81a46ee316feef32fee757a31d25e7d7fbefcbb02
NEAR_TX BbHDs6vD7fioR5oJiFvjh68Cc5bRtQbpF1kbRHxXV9pM
```
https://explorer.near.org/transactions/BbHDs6vD7fioR5oJiFvjh68Cc5bRtQbpF1kbRHxXV9pM

block: 61512024
https://explorer.near.org/blocks/AmvKhSUa136DQfUPpDFxEYHQbqspcb9AeVyNGSffZvi6