### PR TITLE
Resolve 'DB Not Found Error' for skipped block. Resolves #38

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -299,21 +299,38 @@ export class Engine {
         return Ok(result);
     }
     async callFunction(methodName, args, options) {
-        const result = await this.signer.connection.provider.query({
-            request_type: 'call_function',
-            account_id: this.contractID.toString(),
-            method_name: methodName,
-            args_base64: this.prepareInput(args).toString('base64'),
-            finality: options?.block === undefined || options?.block === null
-                ? 'final'
-                : undefined,
-            block_id: options?.block !== undefined && options?.block !== null
-                ? options.block
-                : undefined,
-        });
-        if (result.logs && result.logs.length > 0)
-            console.debug(result.logs); // TODO
-        return Ok(Buffer.from(result.result));
+        let err;
+        for (let i = 0, retries = 3; i < retries; i++) {
+            try {
+                const result = await this.signer.connection.provider.query({
+                    request_type: 'call_function',
+                    account_id: this.contractID.toString(),
+                    method_name: methodName,
+                    args_base64: this.prepareInput(args).toString('base64'),
+                    finality: options?.block === undefined || options?.block === null
+                        ? 'final'
+                        : undefined,
+                    block_id: options?.block !== undefined && options?.block !== null
+                        ? options.block
+                        : undefined,
+                });
+                if (result.logs && result.logs.length > 0)
+                    console.debug(result.logs); // TODO
+                return Ok(Buffer.from(result.result));
+            }
+            catch (error) {
+                if (typeof options === 'object' &&
+                    options.block &&
+                    error.message.startsWith('[-32000] Server error: DB Not Found Error: BLOCK HEIGHT')) {
+                    options.block = (options.block + 1);
+                    err = error.message;
+                }
+                else {
+                    throw error;
+                }
+            }
+        }
+        throw err;
     }
     async callMutativeFunction(methodName, args) {
         this.keyStore.reKey();

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -524,22 +524,41 @@ export class Engine {
     args?: Uint8Array,
     options?: ViewOptions
   ): Promise<Result<Buffer, Error>> {
-    const result = await this.signer.connection.provider.query({
-      request_type: 'call_function',
-      account_id: this.contractID.toString(),
-      method_name: methodName,
-      args_base64: this.prepareInput(args).toString('base64'),
-      finality:
-        options?.block === undefined || options?.block === null
-          ? 'final'
-          : undefined,
-      block_id:
-        options?.block !== undefined && options?.block !== null
-          ? options.block
-          : undefined,
-    });
-    if (result.logs && result.logs.length > 0) console.debug(result.logs); // TODO
-    return Ok(Buffer.from(result.result));
+    let err;
+    for (let i = 0, retries = 3; i < retries; i++) {
+      try {
+        const result = await this.signer.connection.provider.query({
+          request_type: 'call_function',
+          account_id: this.contractID.toString(),
+          method_name: methodName,
+          args_base64: this.prepareInput(args).toString('base64'),
+          finality:
+            options?.block === undefined || options?.block === null
+              ? 'final'
+              : undefined,
+          block_id:
+            options?.block !== undefined && options?.block !== null
+              ? options.block
+              : undefined,
+        });
+        if (result.logs && result.logs.length > 0) console.debug(result.logs); // TODO
+        return Ok(Buffer.from(result.result));
+      } catch (error: any) {
+        if (
+          typeof options === 'object' &&
+          options.block &&
+          error.message.startsWith(
+            '[-32000] Server error: DB Not Found Error: BLOCK HEIGHT'
+          )
+        ) {
+          options.block = ((options.block as number) + 1) as BlockID;
+          err = error.message;
+        } else {
+          throw error;
+        }
+      }
+    }
+    throw err;
   }
 
   protected async callMutativeFunction(


### PR DESCRIPTION
When encountering `DB Not Found Error` during `callFunction` let's skip that block and move to the next one.