### PR TITLE
Fix getAuroraErc20Address method

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -4,7 +4,7 @@ import { BlockProxy, parseBlockID, } from './block.js';
 import { NETWORKS } from './config.js';
 import { KeyStore } from './key_store.js';
 import { Err, Ok } from './prelude.js';
-import { SubmitResult, FunctionCallArgsV2, GetStorageAtArgs, InitCallArgs, NewCallArgs, ViewCallArgs, FungibleTokenMetadata, TransactionStatus, WrappedSubmitResult, CallArgs, } from './schema.js';
+import { SubmitResult, FunctionCallArgsV2, GetStorageAtArgs, GetErc20FromNep141CallArgs, InitCallArgs, NewCallArgs, ViewCallArgs, FungibleTokenMetadata, TransactionStatus, WrappedSubmitResult, CallArgs, } from './schema.js';
 import { TransactionID } from './transaction.js';
 import { base58ToBytes } from './utils.js';
 import { defaultAbiCoder } from '@ethersproject/abi';
@@ -252,8 +252,8 @@ export class Engine {
         return result.map(toBigIntBE);
     }
     async getAuroraErc20Address(nep141, options) {
-        const args = Buffer.from(nep141.id, 'utf-8');
-        const result = await this.callFunction('get_erc20_from_nep141', args, options);
+        const args = new GetErc20FromNep141CallArgs(Buffer.from(nep141.id, 'utf-8'));
+        const result = await this.callFunction('get_erc20_from_nep141', args.encode(), options);
         return result.map((output) => {
             return Address.parse(output.toString('hex')).unwrap();
         });

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -47,6 +47,7 @@ declare const _default: {
     FunctionCallArgsV1: typeof schema.FunctionCallArgsV1;
     GetChainID: typeof schema.GetChainID;
     GetStorageAtArgs: typeof schema.GetStorageAtArgs;
+    GetErc20FromNep141CallArgs: typeof schema.GetErc20FromNep141CallArgs;
     LogEventWithAddress: typeof schema.LogEventWithAddress;
     LogEvent: typeof schema.LogEvent;
     MetaCallArgs: typeof schema.MetaCallArgs;

--- a/lib/schema.d.ts
+++ b/lib/schema.d.ts
@@ -134,6 +134,10 @@ export declare class GetStorageAtArgs extends Assignable {
     key: Uint8Array;
     constructor(address: Uint8Array, key: Uint8Array);
 }
+export declare class GetErc20FromNep141CallArgs extends Assignable {
+    nep141: Buffer;
+    constructor(nep141: Buffer);
+}
 export declare class LogEventWithAddress extends Assignable {
     readonly address: Uint8Array;
     readonly topics: RawU256[];

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -223,6 +223,14 @@ export class GetStorageAtArgs extends Assignable {
         this.key = key;
     }
 }
+// Borsh-encoded parameters for the `get_erc20_from_nep141` method.
+export class GetErc20FromNep141CallArgs extends Assignable {
+    constructor(nep141) {
+        super();
+        this.nep141 = nep141;
+        this.nep141 = nep141;
+    }
+}
 // Borsh-encoded log for use in a latest `SubmitResult`.
 export class LogEventWithAddress extends Assignable {
     constructor(args) {
@@ -470,6 +478,13 @@ const SCHEMA = new Map([
                 ['address', [20]],
                 ['key', [32]],
             ],
+        },
+    ],
+    [
+        GetErc20FromNep141CallArgs,
+        {
+            kind: 'struct',
+            fields: [['nep141', ['u8']]],
         },
     ],
     [

--- a/src/account.ts
+++ b/src/account.ts
@@ -40,7 +40,7 @@ export class Address {
   static parse(id?: string): Result<Address, string> {
     try {
       return Ok(new Address(parseAddress(id!)));
-  } catch (error: any) {
+    } catch (error: any) {
       return Err(error.message);
     }
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -16,6 +16,7 @@ import {
   SubmitResult,
   FunctionCallArgsV2,
   GetStorageAtArgs,
+  GetErc20FromNep141CallArgs,
   InitCallArgs,
   NewCallArgs,
   ViewCallArgs,
@@ -447,11 +448,13 @@ export class Engine {
     nep141: AccountID,
     options?: ViewOptions
   ): Promise<Result<Address, Error>> {
-    const args = Buffer.from(nep141.id, 'utf-8');
+    const args = new GetErc20FromNep141CallArgs(
+      Buffer.from(nep141.id, 'utf-8')
+    );
 
     const result = await this.callFunction(
       'get_erc20_from_nep141',
-      args,
+      args.encode(),
       options
     );
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -298,6 +298,14 @@ export class GetStorageAtArgs extends Assignable {
   }
 }
 
+// Borsh-encoded parameters for the `get_erc20_from_nep141` method.
+export class GetErc20FromNep141CallArgs extends Assignable {
+  constructor(public nep141: Buffer) {
+    super();
+    this.nep141 = nep141;
+  }
+}
+
 // Borsh-encoded log for use in a latest `SubmitResult`.
 export class LogEventWithAddress extends Assignable {
   public readonly address: Uint8Array;
@@ -581,6 +589,13 @@ const SCHEMA = new Map<Function, any>([
         ['address', [20]],
         ['key', [32]],
       ],
+    },
+  ],
+  [
+    GetErc20FromNep141CallArgs,
+    {
+      kind: 'struct',
+      fields: [['nep141', ['u8']]],
     },
   ],
   [


### PR DESCRIPTION
### USDT token metadata

ERC-20: https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7
NEP-141: https://explorer.mainnet.near.org/accounts/dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near
Aurora ERC-20 (BlockScout): https://explorer.mainnet.aurora.dev/address/0x4988a896b1227218e4A686fdE5EabdcAbd91571f
Aurora ERC-20 (Aurorascan): https://aurorascan.dev/address/0x4988a896b1227218e4A686fdE5EabdcAbd91571f

### Before
```
$ node lib/aurora.js get-aurora-erc20 0xdac17f958d2ee523a2206206994597c13d831ec7 --network mainnet


/Users/pavel/dev/aurora/aurora-cli/node_modules/.pnpm/near-api-js@0.39.0/node_modules/near-api-js/lib/providers/json-rpc-provider.js:80
            throw new errors_1.TypedError(`Querying ${args} failed: ${result.error}.\n${JSON.stringify(result, null, 2)}`, rpc_errors_1.getErrorTypeFromErrorMessage(result.error));
                  ^

TypedError: Querying [object Object] failed: wasm execution failed with error: FunctionCallError(HostError(GuestPanic { panic_msg: "ERR_ARG_PARSE" })).
{
  "block_hash": "6W358ikhEEDnvtk3cqVqWQfWsoHf9kYeNqXp8akYbqX7",
  "block_height": 71713592,
  "error": "wasm execution failed with error: FunctionCallError(HostError(GuestPanic { panic_msg: \"ERR_ARG_PARSE\" }))",
  "logs": []
}
    at JsonRpcProvider.query (/Users/pavel/dev/aurora/aurora-cli/node_modules/.pnpm/near-api-js@0.39.0/node_modules/near-api-js/lib/providers/json-rpc-provider.js:80:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Engine.callFunction (file:///Users/pavel/dev/aurora/aurora-cli/node_modules/.pnpm/github.com+aurora-is-near+aurora.js@1ebcad6a45f1f000936654d0554fd78cfaf04f82/node_modules/@aurora-is-near/engine/lib/engine.js:310:32)
    at async Engine.getAuroraErc20Address (file:///Users/pavel/dev/aurora/aurora-cli/node_modules/.pnpm/github.com+aurora-is-near+aurora.js@1ebcad6a45f1f000936654d0554fd78cfaf04f82/node_modules/@aurora-is-near/engine/lib/engine.js:256:24)
    at async Command.<anonymous> (file:///Users/pavel/dev/aurora/aurora-cli/lib/aurora.js:233:32) {
  type: 'UntypedError',
  context: undefined
}
```


### After

```
$ node lib/aurora.js get-aurora-erc20 0xdac17f958d2ee523a2206206994597c13d831ec7 --network mainnet

0x4988a896b1227218e4A686fdE5EabdcAbd91571f
```